### PR TITLE
chore: remove util folder

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,11 +1,11 @@
-import { LocaleCode } from '@tablecheck/locales';
+import { LocaleCode, ordered as orderedLocales } from '@tablecheck/locales';
 import i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
-
-import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from 'utils/constants';
-
 import en from './locales/en.json';
+
+const SUPPORTED_LOCALES = orderedLocales.map(({ code }) => code);
+const DEFAULT_LOCALE = LocaleCode.English;
 
 i18next
   .use(initReactI18next)

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,0 @@
-import { LocaleCode, ordered as orderedLocales } from '@tablecheck/locales';
-
-export const SUPPORTED_LOCALES = orderedLocales.map(({ code }) => code);
-export const DEFAULT_LOCALE = LocaleCode.English;


### PR DESCRIPTION
Colocate i18n constants in their domain. Utils are by definition domain-agnostic, these constants are domain-specific.

fixes #11