### PR TITLE
chore: remove formspree dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,23 +2,14 @@
 
 DEMO: [tc-spa-boilerplate.netlify.app](https://tc-spa-boilerplate.netlify.app)
 
-## Features
-
-- Main tech stack: React, TypeScript, Emotion, i18n
-- Tablekit integration with FontAwesome icons and Dark Mode
-- Basic localized routing
-- Basic layout with footer, top and side navs
-- Language Selection
-- Responsive
-- Basic FormSpree contact form
-
 ## Getting started
 
 - Install [Node.js](https://nodejs.org/en/download/) and [NVM](https://github.com/nvm-sh/nvm#installing-and-updating)
-- Fork/Clone this project
+- Clone or this project and ensure all the boilerplate code is committed onto `main`
 - Run `nvm use` or `nvm use <version>` (on machines running Windows)
 - Run `npm i --legacy-peer-deps` (will install the dependencies)
 - Run `npm start` (will start the app in http://localhost:3000/)
+- Commit all your work onto `development` and deploy that branch
 
 ## Deploy to production
 
@@ -50,10 +41,6 @@ when asked:
 ## Support
 
 Create an issue in the Github repository
-
-## Resources
-
-- [i18n Manager](https://www.electronjs.org/apps/i18n-manager): helpful editor for the translations
 
 ## Contributing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,13 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "spa-boilerplate",
       "version": "0.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@emotion/react": "11.9.3",
         "@emotion/styled": "11.9.3",
-        "@formspree/core": "2.7.0",
-        "@formspree/react": "2.3.0",
         "@fortawesome/free-brands-svg-icons": "5.15.4",
         "@fortawesome/free-regular-svg-icons": "5.15.4",
         "@fortawesome/free-solid-svg-icons": "5.15.4",
@@ -2733,30 +2732,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/@formspree/core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@formspree/core/-/core-2.7.0.tgz",
-      "integrity": "sha512-xSt1VSXgQnRFvg1lCMIMMRJn9GKrcNuuateif0Jqcx4JJhUHZTIDZNNXEMU1VVkI97HUAPgdGekXW8a+Xu2plw==",
-      "dependencies": {
-        "@stripe/stripe-js": "^1.29.0",
-        "@types/promise-polyfill": "^6.0.3",
-        "fetch-ponyfill": "^6.1.0",
-        "promise-polyfill": "^8.1.3"
-      }
-    },
-    "node_modules/@formspree/react": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formspree/react/-/react-2.3.0.tgz",
-      "integrity": "sha512-QBHb4mNP3uNPkBfGZ6m4ox0o/Y3ee6L6p/RMRV19C4slXxVxL+TM2vxUvKv/SuUf5ydiXLCCQtYqpVlcG1xHig==",
-      "dependencies": {
-        "@formspree/core": "^2.7.0",
-        "@stripe/react-stripe-js": "^1.7.1",
-        "@stripe/stripe-js": "^1.27.0"
-      },
-      "peerDependencies": {
-        "react": ">= 17.0.2"
       }
     },
     "node_modules/@fortawesome/fontawesome-common-types": {
@@ -6697,24 +6672,6 @@
         "react-dom": "^16.8.0 || ^17.0.0"
       }
     },
-    "node_modules/@stripe/react-stripe-js": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-1.9.0.tgz",
-      "integrity": "sha512-Fn49X+Gu5fOTxhPOita1cPMi0jw+0v4xfJ3FCXbbvmfuuDl3M7ZvpRkoijBjql11NXsaXO3TMm3rkN3mEolJzw==",
-      "dependencies": {
-        "prop-types": "^15.7.2"
-      },
-      "peerDependencies": {
-        "@stripe/stripe-js": "^1.32.0",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
-      }
-    },
-    "node_modules/@stripe/stripe-js": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.32.0.tgz",
-      "integrity": "sha512-7EvBnbBfS1aynfLRmBFcuumHNGjKxnNkO47rorFBktqDYHwo7Yw6pfDW2iqq0R8r7i7XiJEdWPvvEgQAiDrx3A=="
-    },
     "node_modules/@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -7661,11 +7618,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz",
       "integrity": "sha512-VjID5MJb1eGKthz2qUerWT8+R4b9N+CHvGCzg9fn4kWZgaF9AhdYikQio3R7wV8YY1NsQKPaCwKz1Yff+aHNUQ=="
-    },
-    "node_modules/@types/promise-polyfill": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/promise-polyfill/-/promise-polyfill-6.0.4.tgz",
-      "integrity": "sha512-GSCjjH6mDS8jgpT22rEOkZVqZcYj7i9AHJu4ntpvoohEpa0mLAKP/Kz3POMKqABaFsS4TyNHOeoyWpzycddcoQ=="
     },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
@@ -15625,14 +15577,6 @@
       "optional": true,
       "dependencies": {
         "pend": "~1.2.0"
-      }
-    },
-    "node_modules/fetch-ponyfill": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-6.1.1.tgz",
-      "integrity": "sha512-rWLgTr5A44/XhvCQPYj0X9Tc+cjUaHofSM4lcwjc9MavD5lkjIhJ+h8JQlavPlTIgDpwhuRozaIykBvX9ItaSA==",
-      "dependencies": {
-        "node-fetch": "~2.6.0"
       }
     },
     "node_modules/fetch-retry": {
@@ -26103,11 +26047,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g=="
-    },
-    "node_modules/promise-polyfill": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
-      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg=="
     },
     "node_modules/promise.allsettled": {
       "version": "1.0.5",
@@ -38412,27 +38351,6 @@
         }
       }
     },
-    "@formspree/core": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/@formspree/core/-/core-2.7.0.tgz",
-      "integrity": "sha512-xSt1VSXgQnRFvg1lCMIMMRJn9GKrcNuuateif0Jqcx4JJhUHZTIDZNNXEMU1VVkI97HUAPgdGekXW8a+Xu2plw==",
-      "requires": {
-        "@stripe/stripe-js": "^1.29.0",
-        "@types/promise-polyfill": "^6.0.3",
-        "fetch-ponyfill": "^6.1.0",
-        "promise-polyfill": "^8.1.3"
-      }
-    },
-    "@formspree/react": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@formspree/react/-/react-2.3.0.tgz",
-      "integrity": "sha512-QBHb4mNP3uNPkBfGZ6m4ox0o/Y3ee6L6p/RMRV19C4slXxVxL+TM2vxUvKv/SuUf5ydiXLCCQtYqpVlcG1xHig==",
-      "requires": {
-        "@formspree/core": "^2.7.0",
-        "@stripe/react-stripe-js": "^1.7.1",
-        "@stripe/stripe-js": "^1.27.0"
-      }
-    },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.3.0.tgz",
@@ -41473,19 +41391,6 @@
         "store2": "^2.12.0"
       }
     },
-    "@stripe/react-stripe-js": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@stripe/react-stripe-js/-/react-stripe-js-1.9.0.tgz",
-      "integrity": "sha512-Fn49X+Gu5fOTxhPOita1cPMi0jw+0v4xfJ3FCXbbvmfuuDl3M7ZvpRkoijBjql11NXsaXO3TMm3rkN3mEolJzw==",
-      "requires": {
-        "prop-types": "^15.7.2"
-      }
-    },
-    "@stripe/stripe-js": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/@stripe/stripe-js/-/stripe-js-1.32.0.tgz",
-      "integrity": "sha512-7EvBnbBfS1aynfLRmBFcuumHNGjKxnNkO47rorFBktqDYHwo7Yw6pfDW2iqq0R8r7i7XiJEdWPvvEgQAiDrx3A=="
-    },
     "@szmarczak/http-timer": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
@@ -42249,11 +42154,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@types/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz",
       "integrity": "sha512-VjID5MJb1eGKthz2qUerWT8+R4b9N+CHvGCzg9fn4kWZgaF9AhdYikQio3R7wV8YY1NsQKPaCwKz1Yff+aHNUQ=="
-    },
-    "@types/promise-polyfill": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@types/promise-polyfill/-/promise-polyfill-6.0.4.tgz",
-      "integrity": "sha512-GSCjjH6mDS8jgpT22rEOkZVqZcYj7i9AHJu4ntpvoohEpa0mLAKP/Kz3POMKqABaFsS4TyNHOeoyWpzycddcoQ=="
     },
     "@types/prop-types": {
       "version": "15.7.5",
@@ -48481,14 +48381,6 @@
       "optional": true,
       "requires": {
         "pend": "~1.2.0"
-      }
-    },
-    "fetch-ponyfill": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/fetch-ponyfill/-/fetch-ponyfill-6.1.1.tgz",
-      "integrity": "sha512-rWLgTr5A44/XhvCQPYj0X9Tc+cjUaHofSM4lcwjc9MavD5lkjIhJ+h8JQlavPlTIgDpwhuRozaIykBvX9ItaSA==",
-      "requires": {
-        "node-fetch": "~2.6.0"
       }
     },
     "fetch-retry": {
@@ -56649,11 +56541,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",
       "integrity": "sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g=="
-    },
-    "promise-polyfill": {
-      "version": "8.2.3",
-      "resolved": "https://registry.npmjs.org/promise-polyfill/-/promise-polyfill-8.2.3.tgz",
-      "integrity": "sha512-Og0+jCRQetV84U8wVjMNccfGCnMQ9mGs9Hv78QFe+pSDD3gWTpz0y+1QCuxy5d/vBFuZ3iwP2eycAkvqIMPmWg=="
     },
     "promise.allsettled": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -24,8 +24,6 @@
   "dependencies": {
     "@emotion/react": "11.9.3",
     "@emotion/styled": "11.9.3",
-    "@formspree/core": "2.7.0",
-    "@formspree/react": "2.3.0",
     "@fortawesome/free-brands-svg-icons": "5.15.4",
     "@fortawesome/free-regular-svg-icons": "5.15.4",
     "@fortawesome/free-solid-svg-icons": "5.15.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,10 +6,9 @@ import { BrowserRouter } from 'react-router-dom';
 import { useAsync } from 'react-use';
 
 import { AppThemeProvider } from 'Common/Theme';
-import { MainWrapper } from 'styles';
+import { Router } from 'Router';
 import { getI18nextInstance, initI18n } from 'i18n';
-
-import { Router } from './Router';
+import { MainWrapper } from 'styles';
 
 export function App(): JSX.Element {
   const [isDarkMode, setDarkMode] = React.useState(false);

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -2,9 +2,8 @@ import { ordered as orderedLocales } from '@tablecheck/locales';
 import { useTranslation } from 'react-i18next';
 import { Navigate, Route, Routes } from 'react-router-dom';
 
-import { Home } from 'Pages/Home';
-
 import { PageLayout } from 'Common/Page';
+import { Home } from 'Pages/Home';
 
 export const SUPPORTED_LOCALES = orderedLocales.map(({ code }) => code);
 


### PR DESCRIPTION
It was used on the contact page which was removed in the last commit

fixes #15